### PR TITLE
Let the DRF responder set the content type

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-willing-zg"
-version = "0.1.0"
+version = "0.2.0"
 description = ""
 readme = "README.md"
 authors = ["Bequest, Inc. <oss@willing.com>"]

--- a/willing_zg/views.py
+++ b/willing_zg/views.py
@@ -6,6 +6,4 @@ from rest_framework.decorators import api_view
 
 @api_view(["GET"])
 def get_frontend_env(request):
-    return Response(
-        getattr(settings, "ZYGOAT_FRONTEND_META_CONFIG", {}), content_type="application/json"
-    )
+    return Response(getattr(settings, "ZYGOAT_FRONTEND_META_CONFIG", {}))


### PR DESCRIPTION
This was breaking the response because DRF determines the content type based on the request headers/client/whatnot. Setting it manually should not be needed, and causes errors for our health checking.