### PR TITLE
Add session expiration middleware

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+from django.conf import settings
+
+
+def pytest_configure():
+    settings.configure(SESSION_ENGINE="django.contrib.sessions.backends.file")

--- a/tests/test_django_willing_zg.py
+++ b/tests/test_django_willing_zg.py
@@ -1,5 +1,0 @@
-from django_willing_zg import __version__
-
-
-def test_version():
-    assert __version__ == "0.1.0"

--- a/tests/test_session_expiration_middleware.py
+++ b/tests/test_session_expiration_middleware.py
@@ -1,0 +1,100 @@
+from functools import reduce
+
+import pytest
+from django.contrib.sessions.middleware import SessionMiddleware
+from django.http import HttpResponse
+from django.test import RequestFactory
+from django.test.utils import freeze_time
+
+from willing_zg.middleware import (
+    session_expiration_middleware,
+    SESSION_EXIRATION_KEY,
+    SESSION_EXPIRATION_SECONDS,
+)
+
+TEST_SESSION_KEY = "test_key"
+TEST_SESSION_VALUE = "test_value"
+TEST_SESSION_DATA = {
+    TEST_SESSION_KEY: TEST_SESSION_VALUE,
+    SESSION_EXIRATION_KEY: 0.0,
+}
+
+
+def set_session_middleware(data=None):
+    if data is None:
+        data = {}
+
+    def middleware(process_request):
+        def inner(request):
+            for key, value in data.items():
+                request.session[key] = value
+            return process_request(request)
+
+        return inner
+
+    return middleware
+
+
+def handle_request(request, view, session_data=None):
+    middlewares = [
+        session_expiration_middleware,
+        set_session_middleware(session_data),
+        SessionMiddleware,
+    ]
+    return reduce(lambda f, g: g(f), middlewares, view)(request)
+
+
+@pytest.fixture
+def req():
+    return RequestFactory().get("/")
+
+
+def test_no_session(req):
+    def view(request):
+        return HttpResponse()
+
+    handle_request(req, view)
+
+    assert req.session.is_empty()
+
+
+def test_new_session(req):
+    def view(request):
+        request.session[TEST_SESSION_KEY] = TEST_SESSION_VALUE
+        return HttpResponse()
+
+    handle_request(req, view)
+
+    assert req.session.get(SESSION_EXIRATION_KEY) is not None
+    assert req.session.get(TEST_SESSION_KEY) == TEST_SESSION_VALUE
+
+
+def test_session_lasts_until_expiration(req):
+    def view(request):
+        assert request.session.get(TEST_SESSION_KEY) == TEST_SESSION_VALUE
+        return HttpResponse()
+
+    with freeze_time(SESSION_EXPIRATION_SECONDS - 1):
+        handle_request(req, view, TEST_SESSION_DATA)
+
+
+def test_session_expires(req):
+    def view(request):
+        assert request.session.is_empty()
+        return HttpResponse()
+
+    with freeze_time(SESSION_EXPIRATION_SECONDS + 1):
+        handle_request(req, view, TEST_SESSION_DATA)
+
+
+def test_session_activity_updates(req):
+    def view(request):
+        return HttpResponse()
+
+    request_time = 1000
+
+    with freeze_time(request_time):
+        handle_request(req, view, TEST_SESSION_DATA)
+
+    assert req.session[TEST_SESSION_KEY] == TEST_SESSION_VALUE
+    assert req.session[SESSION_EXIRATION_KEY] == request_time

--- a/willing_zg/middleware.py
+++ b/willing_zg/middleware.py
@@ -1,0 +1,39 @@
+import time
+
+from django.conf import settings
+
+SESSION_EXPIRATION_SECONDS = getattr(settings, "SESSION_EXPIRATION_SECONDS", 3600)
+SESSION_EXPIRATION_ACTIVITY_RESETS = getattr(
+    settings, "SESSION_EXPIRATION_ACTIVITY_RESETS", True
+)
+SESSION_EXIRATION_KEY = getattr(settings, "SESSION_EXIRATION_KEY", "_last_active_at")
+
+
+def has_session(request):
+    return hasattr(request, "session") and not request.session.is_empty()
+
+
+def session_expiration_middleware(get_response):
+    """
+    Middleware to expire Django sessions after a predetermined number of seconds has passed.
+    """
+
+    def middleware(request):
+        if has_session(request):
+            last_activity = request.session.get(SESSION_EXIRATION_KEY)
+            if (
+                last_activity is None
+                or time.time() - last_activity > SESSION_EXPIRATION_SECONDS
+            ):
+                request.session.flush()
+
+        response = get_response(request)
+
+        if has_session(request):
+            last_activity = request.session.get(SESSION_EXIRATION_KEY)
+            if last_activity is None or SESSION_EXPIRATION_ACTIVITY_RESETS:
+                request.session[SESSION_EXIRATION_KEY] = time.time()
+
+        return response
+
+    return middleware


### PR DESCRIPTION
If we want sessions to expire on browser close, we cannot use cookie expiration to ensure that sessions expire after a certain amount of time. This adds a middleware that can be used to expire sessions after a period of user inactivity.