### PR TITLE
Ensure that db settings are applied when secret is present

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-willing-zg"
-version = "0.4.1"
+version = "0.4.2"
 description = ""
 readme = "README.md"
 authors = ["Bequest, Inc. <oss@willing.com>"]

--- a/willing_zg/settings/secrets.py
+++ b/willing_zg/settings/secrets.py
@@ -1,6 +1,8 @@
 import os
 import json
+
 import boto3
+from zygoat_django.settings.environment import env
 
 
 def get_secret(secret_arn):
@@ -21,6 +23,10 @@ if "DATABASE_SECRET" in os.environ:
 
     db_url = f"postgres://{db_username}:{db_password}@{db_host}:{db_port}/{db_clusterid}"
     os.environ["DATABASE_URL"] = db_url
+
+    db_config = env.db_url("DATABASE_URL", default="postgres://postgres:postgres@db/postgres")
+
+    DATABASES = {"default": db_config}
 
 if "DJANGO_EMAIL_HOST_PASSWORD" in os.environ:
     django_password = json.loads(


### PR DESCRIPTION
This eliminates the need for this to be set explicitly in the settings of apps that use django-willing-zg.