### PR TITLE
updating the mailer class to add a 'build_email' method to support building messages for mass email sends

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,9 @@ A Django app to hold common utilities for Zygoat-managed applications
 4. Import willing-zg settings into the django settings
 
    from willing_zg.settings import * # noqa
+
+
+## Running locally for development
+1. checkout the directory into the `backend` directory of the app you're developing in
+
+2. modify your Dockerfile.local and add `ADD /django-willing-zg /django-willing-zg` above `WORKDIR /code` and add ` RUN poetry add --editable /django-willing-zg` after poetry install

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-willing-zg"
-version = "0.5.2"
+version = "0.6.0"
 description = ""
 readme = "README.md"
 authors = ["Bequest, Inc. <oss@willing.com>"]

--- a/willing_zg/mailer.py
+++ b/willing_zg/mailer.py
@@ -1,3 +1,4 @@
+from django.core import mail
 from django.core.mail import EmailMultiAlternatives
 from django.template.loader import render_to_string
 from django.conf import settings
@@ -9,7 +10,6 @@ class MailerError(Exception):
 
 class Mailer:
     """The Mailer class holds helper functions for sending template emails"""
-
 
     @classmethod
     def build_email(
@@ -60,6 +60,13 @@ class Mailer:
 
         return message
 
+    @classmethod
+    def send_mass_email(
+        cls,
+        messages,
+    ):
+        connection = mail.get_connection()
+        connection.send_messages(messages)
 
     @classmethod
     def send_email(

--- a/willing_zg/mailer.py
+++ b/willing_zg/mailer.py
@@ -10,8 +10,9 @@ class MailerError(Exception):
 class Mailer:
     """The Mailer class holds helper functions for sending template emails"""
 
+
     @classmethod
-    def send_email(
+    def build_email(
         cls,
         to_emails,
         subject,
@@ -56,6 +57,34 @@ class Mailer:
         if attachments:
             for item in attachments:
                 message.attach(*item)
+
+        return message
+
+
+    @classmethod
+    def send_email(
+        cls,
+        to_emails,
+        subject,
+        template,
+        context,
+        bcc=None,
+        attachments=None,
+        reply_to=None,
+        from_email=None,
+        headers=None,
+    ):
+        message = cls.build_email(
+            to_emails,
+            subject,
+            template,
+            context,
+            bcc=None,
+            attachments=None,
+            reply_to=None,
+            from_email=None,
+            headers=None,
+        )
 
         try:
             message.send()


### PR DESCRIPTION
this adds methods for building messages and then sending them in bulk. Doing this allows us to send multiple messages while only having to establish a single smtp connection