### PR TITLE
Mailer optional arguments fix

### DIFF
--- a/willing_zg/mailer.py
+++ b/willing_zg/mailer.py
@@ -86,11 +86,11 @@ class Mailer:
             subject,
             template,
             context,
-            bcc=None,
-            attachments=None,
-            reply_to=None,
-            from_email=None,
-            headers=None,
+            bcc=bcc or None,
+            attachments=attachments or None,
+            reply_to=reply_to or None,
+            from_email=from_email or None,
+            headers=headers or None,
         )
 
         try:

--- a/willing_zg/mailer.py
+++ b/willing_zg/mailer.py
@@ -86,11 +86,11 @@ class Mailer:
             subject,
             template,
             context,
-            bcc=bcc or None,
-            attachments=attachments or None,
-            reply_to=reply_to or None,
-            from_email=from_email or None,
-            headers=headers or None,
+            bcc,
+            attachments,
+            reply_to,
+            from_email,
+            headers,
         )
 
         try:


### PR DESCRIPTION
Optional arguments were not being passed from `send_email` to `build_email` if they were set when creating the message.